### PR TITLE
Add functionality to pass arguments to internal SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ clipcast client --host REMOTE_HOST [OPTIONS]
 
 Options:
 - `--host`: SSH host to connect to (required)
+- `--ssh-args`: Arguments for SSH session invoked by clipcast (default: )
 - `--write-clipboard-cmd`: Local command to write to clipboard (default: "pbcopy")
 - `--read-clipboard-cmd`: Local command to read from clipboard (default: "pbpaste")
 - `--remote-server-cmd`: Remote clipcast command (default: "clipcast")

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,10 @@ struct Cli {
 enum Cmd {
     #[command(name = "server")]
     Server(ServerCmd),
+
     #[command(name = "client")]
     Client(ClientCmd),
+
     #[command(name = "generate")]
     Generate(GenerateCmd),
 }
@@ -58,6 +60,10 @@ struct ClientCmd {
     /// SSH host to connect to
     #[arg(long)]
     host: String,
+
+    // SSH args
+    #[arg(long, allow_hyphen_values = true, num_args = 1, default_value = "")]
+    ssh_args: String,
 
     /// Command to write to clipboard
     #[arg(long, default_value = "pbcopy")]
@@ -259,7 +265,11 @@ impl Client {
     async fn run_connection(
         &mut self,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut args = vec![self.cmd.host.as_str()];
+        // let mut args = vec![self.cmd.ssh_args.as_str()];
+        let mut args: Vec<&str> = self.cmd.ssh_args.split(' ').collect();
+        args.push(self.cmd.host.as_str());
+        // let mut args = vec![self.cmd.host.as_str()];
+        println!("{:?}", args);
         let mut remote_args =
             vec![self.cmd.remote_server_cmd.clone(), "server".into()];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct ClientCmd {
     #[arg(long)]
     host: String,
 
-    // SSH args
+    /// SSH args
     #[arg(long, allow_hyphen_values = true, num_args = 1, default_value = "")]
     ssh_args: String,
 
@@ -265,11 +265,13 @@ impl Client {
     async fn run_connection(
         &mut self,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // let mut args = vec![self.cmd.ssh_args.as_str()];
-        let mut args: Vec<&str> = self.cmd.ssh_args.split(' ').collect();
-        args.push(self.cmd.host.as_str());
-        // let mut args = vec![self.cmd.host.as_str()];
-        println!("{:?}", args);
+        let mut args: Vec<&str>;
+        if self.cmd.ssh_args.is_empty() {
+            args = vec![self.cmd.host.as_str()];
+        } else {
+            args = self.cmd.ssh_args.split(' ').collect();
+            args.push(self.cmd.host.as_str());
+        }
         let mut remote_args =
             vec![self.cmd.remote_server_cmd.clone(), "server".into()];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct ClientCmd {
     #[arg(long)]
     host: String,
 
-    /// SSH args
+    /// Arguments for SSH session invoked by clipcast
     #[arg(long, allow_hyphen_values = true, num_args = 1, default_value = "")]
     ssh_args: String,
 


### PR DESCRIPTION
This PR adds the ability to pass arguments to the SSH command invoked by clipcast. 

This was motivated by wanting to automatically run clipcast alongside a standard SSH session, using `LocalCommand` in the SSH config. For instance:

```bash
Host DOMAIN*
  HostName %h.REMAINING
  User USER
  IdentityFile PRIVATE_KEY
  ForwardX11 yes
  LocalComand clipcast client --host %h > /dev/null 2>&1 &
```

Unfortunately, this recursively kicks off more and more SSH invocations when `ssh DOMAIN*` is run.

---

This PR lets us run things like: `clipcast client --ssh-args "-F <OTHER_CONFIG>" --host <HOST>`, specifying a secondary SSH config that doesn't include the LocalCommand.

We can use this to automatically kick off clipcast alongside a standard SSH session without the recursive behavior. For example, using the following setup with two SSH configs:

Default SSH Config (`config`):
```bash
Include ~/.ssh/clipcast_config

# Overload included config. to execute clipcast
Host DOMAIN*
  LocalCommand clipcast client --ssh-args "-F $HOME/.ssh/clipcast_config" --host %h /dev/null 2>&1 &
```

Clipcast SSH Config (`clipcast_config`)
```bash
Host DOMAIN*
  HostName %h.REMAINING
  User USER
  IdentityFile PRIVATE_KEY
  ForwardX11 yes
```

---

With the above setup however, the clipcast session still persists after the SSH session ends. I also wrote a short script to run from `LocalCommand` that cleans up this up, and can update the body of this PR with it later if it's of interest to people.